### PR TITLE
fix: Use working installation method for koubou v0.6.1

### DIFF
--- a/Formula/koubou.rb
+++ b/Formula/koubou.rb
@@ -87,7 +87,14 @@ class Koubou < Formula
   end
 
   def install
-    virtualenv_install_with_resources
+    # Create virtualenv and ensure pip is available
+    system Formula["python@3.12"].opt_bin/"python3.12", "-m", "venv", libexec
+    
+    # Install koubou from source, but allow binary wheels for dependencies (like Pillow)
+    system libexec/"bin/pip", "install", "--no-binary", "koubou", "."
+    
+    # Create wrapper script
+    bin.install_symlink libexec/"bin/kou"
   end
 
   def caveats


### PR DESCRIPTION
The previous fix changed the installation method from the working approach used in v0.6.0 to virtualenv_install_with_resources, which tries to build all dependencies from source, causing Pillow to fail on macOS 26.

This restores the working installation method:
- Build koubou from source with `--no-binary koubou`  
- Allow binary wheels for dependencies (especially Pillow)
- Keep all other audit compliance fixes

Fixes installation failures on macOS 26 and other platforms where building Pillow from source is problematic.

## Key Change
```ruby
# Before (failing)
virtualenv_install_with_resources

# After (working)
system libexec/"bin/pip", "install", "--no-binary", "koubou", "."
```