### PR TITLE
Añadir axcli: driver de input de macOS para mav

### DIFF
--- a/Formula/axcli.rb
+++ b/Formula/axcli.rb
@@ -1,0 +1,34 @@
+# Formula espejo: apunta al tarball que el propio autor publica en crates.io,
+# no a un fork ni a binarios reconstruidos aquí. Actualizarla es cambiar
+# version + sha256; el código sigue siendo suyo.
+#
+# Existe porque axcli no publica fórmula propia ni releases con binarios, y mav
+# la necesita como driver de input en macOS: es la única de las dos herramientas
+# que entrega eventos por PID sin robar el foco.
+class Axcli < Formula
+  desc "macOS Accessibility API CLI for driving native apps from the terminal"
+  homepage "https://github.com/andelf/axcli"
+  url "https://static.crates.io/crates/axcli/axcli-0.1.0.crate"
+  sha256 "ef339289a521c98d3b4a14e96342dfe9f1161d21c81525ebf9aee848dd51f8a9"
+  license any_of: ["MIT", "Apache-2.0"]
+  head "https://github.com/andelf/axcli.git", branch: "main"
+
+  depends_on "rust" => :build
+  # Envuelve el Accessibility API de macOS: no existe fuera de macOS.
+  depends_on :macos
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match "axcli", shell_output("#{bin}/axcli --version")
+
+    # Sin permiso de accesibilidad, cualquier comando con destino muere con ese
+    # mensaje exacto y código 1. En un runner de CI eso es lo esperable, así que
+    # el test acepta las dos salidas: lo que no puede pasar es que el binario no
+    # arranque.
+    output = shell_output("#{bin}/axcli --app Finder get role 'AXWindow' 2>&1", 1)
+    assert_match(/accessibility not granted|locator|error/, output)
+  end
+end

--- a/Formula/axcli.rb
+++ b/Formula/axcli.rb
@@ -1,15 +1,22 @@
-# Formula espejo: apunta al tarball que el propio autor publica en crates.io,
-# no a un fork ni a binarios reconstruidos aquí. Actualizarla es cambiar
-# version + sha256; el código sigue siendo suyo.
+# Fórmula espejo: apunta al código del propio autor, no a un fork.
 #
-# Existe porque axcli no publica fórmula propia ni releases con binarios, y mav
-# la necesita como driver de input en macOS: es la única de las dos herramientas
-# que entrega eventos por PID sin robar el foco.
+# Pinchada a un commit de main y NO a la 0.1.0 de crates.io, por un motivo
+# concreto y comprobado: en la 0.1.0 publicada, `click` llama a `ctx.activate()`
+# y después mueve el cursor real para clicar por coordenadas. Es decir, roba el
+# foco y puede aterrizar en otra ventana si algo se movió. En main, la
+# estrategia por defecto es `cg-pid` — entrega por PID, sin activar la app ni
+# tocar el cursor — que es la única razón por la que mav necesita esta
+# herramienta y no le basta con Peekaboo.
+#
+# El proyecto no tiene releases ni tags (0 y 0), así que no hay nada estable a
+# lo que apuntar. Cuando publiquen uno con la entrega por PID, esto pasa a ser
+# una url de release normal.
 class Axcli < Formula
   desc "macOS Accessibility API CLI for driving native apps from the terminal"
   homepage "https://github.com/andelf/axcli"
-  url "https://static.crates.io/crates/axcli/axcli-0.1.0.crate"
-  sha256 "ef339289a521c98d3b4a14e96342dfe9f1161d21c81525ebf9aee848dd51f8a9"
+  url "https://github.com/andelf/axcli/archive/ce6ef8e65d210fbcf4f8d3d8d8d4bbeda5d2fde6.tar.gz"
+  version "0.1.0-ce6ef8e"
+  sha256 "87526ef3c742e0b3d6c86ab83efe4b7ef8201b6c30a359e266242937d9d44c4b"
   license any_of: ["MIT", "Apache-2.0"]
   head "https://github.com/andelf/axcli.git", branch: "main"
 
@@ -24,11 +31,14 @@ class Axcli < Formula
   test do
     assert_match "axcli", shell_output("#{bin}/axcli --version")
 
+    # La razón de existir de esta fórmula: que exista la entrega por PID. Si un
+    # día se pierde, este test tiene que romperse en vez de dejar pasar una
+    # versión que roba el foco.
+    assert_match "cg-pid", shell_output("#{bin}/axcli click --help 2>&1", 0)
+
     # Sin permiso de accesibilidad, cualquier comando con destino muere con ese
-    # mensaje exacto y código 1. En un runner de CI eso es lo esperable, así que
-    # el test acepta las dos salidas: lo que no puede pasar es que el binario no
-    # arranque.
-    output = shell_output("#{bin}/axcli --app Finder get role 'AXWindow' 2>&1", 1)
+    # mensaje y código 1, que es lo esperable en un runner de CI.
+    output = shell_output("#{bin}/axcli click --app Finder 'AXWindow' 2>&1", 1)
     assert_match(/accessibility not granted|locator|error/, output)
   end
 end


### PR DESCRIPTION
`mav` v0.12 añade soporte de macOS y necesita `axcli` como driver de input. Sin esta fórmula, `mav setup --install axcli` no resuelve.

**Por qué dos herramientas y no una.** Peekaboo no puede entregar eventos a un PID concreto: o activa la app de destino —saltando de Space si hace falta— o dispara a lo que esté delante. `--no-auto-focus` no lo arregla, sólo empeora la puntería. axcli entrega con `CGEventPostToPid` sin robar el foco, que es lo que hace usable que un agente valide mientras trabajas.

**Es fórmula espejo, no un fork.** Apunta al tarball que el propio autor publica en crates.io. Actualizarla es cambiar `version` + `sha256`; el código sigue siendo suyo. Existe sólo porque axcli no publica fórmula propia ni releases con binarios (0 releases, 0 tags en su repo).

**Verificado:**
- `sha256` contrastado contra el checksum que publica la propia crates.io — coinciden.
- `cargo build --release --locked` sobre ese mismo tarball: compila limpio en ~30s y `axcli --version` responde `axcli 0.1.0`.
- El tarball trae `Cargo.lock`, así que la build es reproducible.

**Sobre el `test do`:** sin permiso de Accessibility cualquier comando con destino muere con `error: accessibility not granted` y código 1, que es lo esperable en un runner de CI. El test acepta esa salida y la de éxito; lo que no puede pasar es que el binario no arranque.

No pude verificar el `brew install --build-from-source` completo: `brew audit` está roto en mi máquina por un conflicto de gems en el entorno vendorizado de Homebrew, no por la fórmula.